### PR TITLE
docs: add MEQ-JAX and FORGE from issue #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ A curated list of awesome machine learning resources for plasma physics, tokamak
 - [ToFu](https://github.com/ToFuProject/tofu) - IMAS-compatible Python library for synthetic diagnostics, ray tracing, and tomography for fusion devices
 - [RT-GSFit](https://github.com/tokamak-energy/rtgsfit) [WIP] - Real-time Grad-Shafranov equilibrium reconstruction code deployed on ST40 and being generalized beyond device-specific workflows
 - [cfsem-py](https://github.com/cfs-energy/cfsem-py) - Python/Rust quasi-steady electromagnetics toolkit covering filament models, Biot-Savart calculations, and Grad-Shafranov utilities
+- [MEQ-JAX](https://gitlab.epfl.ch/spc/public/meq/meq_jax) - JAX rewrite of the MEQ magnetic equilibrium solver enabling automatic differentiation, batching, and GPU/TPU acceleration (EPFL SPC, experimental)
+- [FORGE](https://github.com/FORGExhaust/FORGE) - Python tool for optimising tokamak divertor magnetic geometries via simulated annealing (LGPL-3.0)
 
 ### Machine Learning Frameworks for Plasma Physics
 


### PR DESCRIPTION
## Summary

Adds 2 tools from issue #3 that were not yet in the README:

- **MEQ-JAX** — JAX rewrite of the MEQ magnetic equilibrium solver (EPFL SPC), enabling automatic differentiation, batching, and GPU/TPU acceleration. Experimental, supports FGE subset.
- **FORGE** — Python tool for optimising tokamak divertor magnetic geometries via simulated annealing (LGPL-3.0, 7 stars, actively maintained).

The 2 papers from issue #3 comments (Liu 2024, Seo 2021) were already in the bibliography and README.

Closes #3